### PR TITLE
Strip nested vendor directories during glide install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ clean-glide-cache:
 	-rm -rf ./.glide
 
 $(VENDOR_DIR): glide.lock glide.yaml
-	$(GLIDE_BIN) --quiet install
+	$(GLIDE_BIN) --quiet install --strip-vendor
 	touch $(VENDOR_DIR)
 
 .PHONY: deps


### PR DESCRIPTION
This PR adds the --strip-vendor argument to "glide install" when building WIT. Nested vendor directories can cause odd build failures such as:
controller/apps_kubeclient.go:587: cannot use valDec (type *"github.com/fabric8-services/fabric8-wit/vendor/k8s.io/apimachinery/vendor/gopkg.in/inf.v0".Dec) as type *"github.com/fabric8-services/fabric8-wit/vendor/gopkg.in/inf.v0".Dec in argument to decToInt32