### PR TITLE
Also specify --strip-vcs when calling "glide install --strip-vendor"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ clean-glide-cache:
 	-rm -rf ./.glide
 
 $(VENDOR_DIR): glide.lock glide.yaml
-	$(GLIDE_BIN) --quiet install --strip-vendor
+	$(GLIDE_BIN) --quiet install --strip-vendor --strip-vcs
 	touch $(VENDOR_DIR)
 
 .PHONY: deps


### PR DESCRIPTION
Glide versions under 0.12 require you to specify --strip-vcs when calling "glide install" with the --strip-vendor option. Versions of Glide 0.12 or greater turn on this flag automatically. Using it with such a version gives the following warning, but doesn't appear to impact the build in any way:
[WARN]	The --strip-vcs flag is deprecated. This now works by default.