### PR TITLE
 Use buckets for metrics, add metrics implementation for statseries API

### DIFF
--- a/design/apps.go
+++ b/design/apps.go
@@ -66,18 +66,18 @@ var envStatPods = a.Type("EnvStatPods", func() {
 	a.Attribute("quota", d.Integer)
 })
 
-var timedIntTuple = a.Type("TimedIntTuple", func() {
-	a.Description("a set of time and integer values")
-	a.Attribute("time", d.Integer)
-	a.Attribute("value", d.Integer)
+var timedNumberTuple = a.Type("TimedNumberTuple", func() {
+	a.Description("a set of time and number values")
+	a.Attribute("time", d.Number)
+	a.Attribute("value", d.Number)
 })
 
 var simpleDeploymentStatSeries = a.Type("SimpleDeploymentStatSeries", func() {
 	a.Description("pod stat series")
-	a.Attribute("start", d.Integer)
-	a.Attribute("end", d.Integer)
-	a.Attribute("memory", a.ArrayOf(timedIntTuple))
-	a.Attribute("cores", a.ArrayOf(timedIntTuple))
+	a.Attribute("start", d.Number)
+	a.Attribute("end", d.Number)
+	a.Attribute("memory", a.ArrayOf(timedNumberTuple))
+	a.Attribute("cores", a.ArrayOf(timedNumberTuple))
 })
 
 var simpleSpaceSingle = JSONSingle(
@@ -203,11 +203,11 @@ var _ = a.Resource("apps", func() {
 			a.Param("spaceID", d.UUID, "ID of the space")
 			a.Param("appName", d.String, "Name of the application")
 			a.Param("deployName", d.String, "Name of the deployment")
-			a.Param("start", d.Integer, "start time in millis")
-			a.Param("end", d.Integer, "end time in millis")
+			a.Param("start", d.Number, "start time in millis")
+			a.Param("end", d.Number, "end time in millis")
 			a.Param("limit", d.Integer, "maximum number of data points to return")
 		})
-		a.Response(d.OK, simpleDeploymentStatSeries)
+		a.Response(d.OK, simpleDeploymentStatSeriesSingle)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)

--- a/kubernetes/apps_metrics.go
+++ b/kubernetes/apps_metrics.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fabric8-services/fabric8-wit/app"
 	hawkular "github.com/hawkular/hawkular-client-go/metrics"
 	v1 "k8s.io/client-go/pkg/api/v1"
 )
@@ -43,23 +44,65 @@ func newMetricsClient(metricsURL string, token string) (*metricsClient, error) {
 func (mc *metricsClient) getCPUMetrics(pods []v1.Pod, namespace string) (float64, int64, error) {
 	// CPU metrics are in millicores
 	// See: https://github.com/openshift/origin-web-console/blob/v3.6.0/app/scripts/services/metricsCharts.js#L15
-	return mc.getMetricsForPods(pods, namespace, cpuDesc)
+	return mc.getBucketAverage(pods, namespace, cpuDesc)
+}
+
+func (mc *metricsClient) getCPUMetricsRange(pods []v1.Pod, namespace string,
+	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTuple, error) {
+	buckets, err := mc.getBucketsInRange(pods, namespace, cpuDesc, startTime, endTime, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	results := bucketsToTuples(buckets)
+	return results, nil
 }
 
 func (mc *metricsClient) getMemoryMetrics(pods []v1.Pod, namespace string) (float64, int64, error) {
-	return mc.getMetricsForPods(pods, namespace, memDesc)
+	return mc.getBucketAverage(pods, namespace, memDesc)
 }
 
-func (mc *metricsClient) getBucketAverage(pods []v1.Pod, namespace, descTag string) (float64, error) {
-	result, err := mc.readBuckets(pods, namespace, descTag)
+func (mc *metricsClient) getMemoryMetricsRange(pods []v1.Pod, namespace string,
+	startTime time.Time, endTime time.Time, limit int) ([]*app.TimedNumberTuple, error) {
+	buckets, err := mc.getBucketsInRange(pods, namespace, memDesc, startTime, endTime, limit)
 	if err != nil {
-		return -1, err
-	} else if result == nil {
-		return -1, nil
+		return nil, err
 	}
 
+	results := bucketsToTuples(buckets)
+	return results, nil
+}
+
+func bucketsToTuples(buckets []*hawkular.Bucketpoint) []*app.TimedNumberTuple {
+	results := make([]*app.TimedNumberTuple, len(buckets))
+	for idx, bucket := range buckets {
+		// Use bucket start time as timestamp for data, which is what the OSO web console uses:
+		// https://github.com/openshift/origin-web-console/blob/v3.7.0/app/scripts/directives/deploymentMetrics.js#L250
+		bucketTimeUnix := float64(convertToUnixMillis(bucket.Start))
+		results[idx] = &app.TimedNumberTuple{
+			Value: &bucket.Avg,
+			Time:  &bucketTimeUnix,
+		}
+	}
+	return results
+}
+
+func convertToUnixMillis(t time.Time) int64 {
+	return hawkular.ToUnixMilli(t)
+}
+
+func (mc *metricsClient) getBucketAverage(pods []v1.Pod, namespace, descTag string) (float64, int64, error) {
+	result, err := mc.getLatestBucket(pods, namespace, descTag)
+	if err != nil {
+		return -1, -1, err
+	} else if result == nil {
+		return -1, -1, nil
+	}
+
+	// Use start time of bucket as timestamp
+	timestamp := hawkular.ToUnixMilli(result.Start)
 	// Return average from bucket
-	return result.Avg, err
+	return result.Avg, timestamp, err
 }
 
 func (mc *metricsClient) getMetricsForPods(pods []v1.Pod, namespace string, descTag string) (float64, int64, error) {
@@ -114,7 +157,63 @@ func calcAvgTimestamp(samples []*hawkular.Datapoint) int64 {
 	return avg
 }
 
-func (mc *metricsClient) readBuckets(pods []v1.Pod, namespace string, descTag string) (*hawkular.Bucketpoint, error) {
+func (mc *metricsClient) getLatestBucket(pods []v1.Pod, namespace string, descTag string) (*hawkular.Bucketpoint, error) {
+	// Get a bucket for the last minute
+	endTime := time.Now()
+	startTime := endTime.Add(-1 * time.Minute)
+	buckets, err := mc.readBuckets(pods, namespace, descTag, hawkular.StartTimeFilter(startTime),
+		hawkular.EndTimeFilter(endTime), hawkular.BucketsFilter(1))
+	if err != nil {
+		return nil, err
+	} else if len(buckets) == 0 { // Should have gotten at most one bucket
+		return nil, nil
+	}
+	return buckets[0], nil
+}
+
+// Use 1 minute duration for buckets
+const bucketDuration = 1 * time.Minute
+
+func (mc *metricsClient) getBucketsInRange(pods []v1.Pod, namespace string, descTag string, startTime time.Time,
+	endTime time.Time, limit int) ([]*hawkular.Bucketpoint, error) {
+	// Note: returned buckets are ordered by start time
+	// https://github.com/hawkular/hawkular-metrics/blob/0.28.3/core/metrics-model/src/main/java/org/hawkular/metrics/model/BucketPoint.java#L70
+	buckets, err := mc.readBuckets(pods, namespace, descTag, hawkular.StartTimeFilter(startTime),
+		hawkular.EndTimeFilter(endTime), hawkular.BucketsDurationFilter(bucketDuration))
+	if err != nil {
+		return nil, err
+	}
+
+	// Hawkular buckets may extend beyond the requested endpoint if
+	// (endTime - startTime) is not evenly divisible by the bucket duration.
+	// https://github.com/hawkular/hawkular-metrics/blob/0.28.3/core/metrics-model/src/main/java/org/hawkular/metrics/model/Buckets.java#L156
+	//
+	// If the end time is in the future, this bucket may be empty or have fewer
+	// samples than other buckets. This may create outliers in our charts. So
+	// we drop any buckets whose end time is greater than the requested end time
+	//
+	// For comparison, the OSO web console unconditionally drops the last bucket:
+	// https://github.com/openshift/origin-web-console/blob/v3.7.0/app/scripts/directives/deploymentMetrics.js#L422
+	numBuckets := len(buckets)
+	if numBuckets > 0 {
+		lastBucket := buckets[numBuckets-1]
+		if lastBucket.End.After(endTime) {
+			buckets = buckets[:numBuckets-1]
+			numBuckets-- // Later used for limit
+		}
+
+		// If number of buckets is greater than requested limit n, take newest n buckets
+		if limit >= 0 && numBuckets > limit {
+			start := numBuckets - limit
+			buckets = buckets[start:]
+		}
+	}
+
+	return buckets, nil
+}
+
+func (mc *metricsClient) readBuckets(pods []v1.Pod, namespace string, descTag string,
+	filters ...hawkular.Filter) ([]*hawkular.Bucketpoint, error) {
 	numPods := len(pods)
 	if numPods == 0 {
 		return nil, nil
@@ -135,24 +234,9 @@ func (mc *metricsClient) readBuckets(pods []v1.Pod, namespace string, descTag st
 
 	// Tenant should be set to OSO project name
 	mc.hawkularClient.Tenant = namespace
-	// Get a bucket for the last 2 minutes (OSO's bucket duration for last hour shown)
-	startTime := time.Now().Add(-120000 * time.Millisecond)
-	buckets, err := mc.hawkularClient.ReadBuckets(hawkular.Gauge, hawkular.Filters(hawkular.TagsFilter(tags),
-		hawkular.BucketsFilter(1), hawkular.StackedFilter() /* Sum of each pod */, hawkular.StartTimeFilter(startTime)))
-	//	hawkular.BucketsDurationFilter(120000*time.Millisecond), hawkular.StartTimeFilter(time.Now().Add(-60*time.Minute)))) What OSO uses
-	if err != nil {
-		return nil, err
-	}
-
-	// XXX Raw request examples:
-	// {"tags":"descriptor_name:memory/usage|cpu/usage_rate,type:pod_container,pod_id:myuid1|myuid2,container_name:mycontainer","bucketDuration":"120000ms","start":"-60mn"}
-	// {"tags":"descriptor_name:network/tx_rate|network/rx_rate,type:pod,pod_id:myuid1|myuid2","bucketDuration":"120000ms","start":1511293645209}
-
-	// Should have gotten at most one bucket
-	if len(buckets) == 0 {
-		return nil, nil
-	}
-	return buckets[0], nil
+	// Append other filters to those provided
+	filters = append(filters, hawkular.TagsFilter(tags), hawkular.StackedFilter() /* Sum of each pod */)
+	return mc.hawkularClient.ReadBuckets(hawkular.Gauge, hawkular.Filters(filters...))
 }
 
 func (mc *metricsClient) readRaw(pods []v1.Pod, namespace string, descTag string) ([]*hawkular.Datapoint, error) {


### PR DESCRIPTION
This PR switches the metrics gathering for showDeploymentStats to get aggregate data for the last minute using Hawkular's buckets API. It also adds an implementation for the showDeploymentStatSeries API which no longer serves mock data. This too uses buckets for aggregating data across all pods in a deployment over 1 minute intervals. The timestamp used for each tuple is the start time of the corresponding bucket, this matches with what the OpenShift web console does.

I changed some data types to do with timestamps for the showDeploymentStatSeries API, to prevent overflow when reading timestamps on systems using 32-bit ints. Goa (v1) doesn't support int64 types, so I used Number instead which corresponds to a float64.