### PR TITLE
Update Hawkular dependency to include integer overflow fix

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -148,7 +148,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hawkular/hawkular-client-go
-  version: 4863013673fcb807cda3b5103964b084566a4665
+  version: 3ec6f27f0d339f9aee02ee4ad545581e52b40e19
   subpackages:
   - metrics
 - name: github.com/howeyc/fsnotify


### PR DESCRIPTION
I found that the Hawkular Go client was converting timestamps (millseconds since Unix epoch) to int type. This has since been fixed upstream: https://github.com/hawkular/hawkular-client-go/pull/21

This PR simply updates glide.lock to use a version with this fix.