### PR TITLE
Change stats to behave more like statseries, add version and pod total

### DIFF
--- a/controller/apps.go
+++ b/controller/apps.go
@@ -277,7 +277,15 @@ func (c *AppsController) ShowDeploymentStats(ctx *app.ShowDeploymentStatsAppsCon
 		return witerrors.NewNotFoundError("osio space", ctx.SpaceID.String())
 	}
 
-	deploymentStats, err := kc.GetDeployment(*kubeSpaceName, ctx.AppName, ctx.DeployName)
+	var startTime time.Time
+	if ctx.Start != nil {
+		startTime = convertToTime(int64(*ctx.Start))
+	} else {
+		// If a start time was not supplied, default to one minute ago
+		startTime = time.Now().Add(-1 * time.Minute)
+	}
+
+	deploymentStats, err := kc.GetDeploymentStats(*kubeSpaceName, ctx.AppName, ctx.DeployName, startTime)
 	if err != nil {
 		return witerrors.NewInternalError(ctx, err)
 	}
@@ -285,7 +293,7 @@ func (c *AppsController) ShowDeploymentStats(ctx *app.ShowDeploymentStatsAppsCon
 		return witerrors.NewNotFoundError("deployment", ctx.DeployName)
 	}
 
-	res := &app.SimpleDeploymentSingle{
+	res := &app.SimpleDeploymentStatsSingle{
 		Data: deploymentStats,
 	}
 


### PR DESCRIPTION
Sorry for the size of this PR, some refactoring led to more refactoring. This fixes a few outstanding issues with the Kubernetes/Hawkular clients. It adds makes data returned from the stats endpoint include timestamps, and adds a total number of pods when querying pod status. Both of these were requested by those working on the frontend. It also adds the application's version number for each deployment returned from the deployments endpoint, which is something we'll need to show in UI.

The PR converts all remaining metrics to use the Number Goa data type, and removes some code where we converted to int32. This allows us to express larger quantities and to return CPU metrics in fractions of cores instead of millicores. It also adds a start time parameter to the stats endpoint. This allows for consistently spaced metrics when combined with the statseries. Say the statseries endpoint gives you datapoints for time x, x + 1 minute, x + 2 minutes, then passing a start time of x + 3 minutes to the stat endpoint will give you the next datapoint in the series. Rather than add a start time parameter to any other API dealing with deployments (e.g. showSpace, showApplication), I split the behaviour of showDeployments and showDeploymentStats. The former returns version and pod info for a deployment, while the latter returns time series-based metrics data. I also split the structs for deployment stats and environment stats, since the latter deals with quotas and is not time series-based.