### PR TITLE
Refactor Kube/MetricsClient into testable interfaces, add initial tests

### DIFF
--- a/controller/apps.go
+++ b/controller/apps.go
@@ -143,7 +143,7 @@ func getTokenData(authClient authservice.Client, ctx context.Context, forService
 
 // getKubeClient createa kube client for the appropriate cluster assigned to the current user.
 // many different errors are possible, so controllers should call getAndCheckKubeClient() instead
-func (c *AppsController) getKubeClient(ctx context.Context) (*kubernetes.KubeClient, error) {
+func (c *AppsController) getKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error) {
 
 	// create Auth API client
 	authClient, err := auth.CreateClient(ctx, c.Config)
@@ -179,7 +179,12 @@ func (c *AppsController) getKubeClient(ctx context.Context) (*kubernetes.KubeCli
 	}
 
 	// create the cluster API client
-	kc, err := kubernetes.NewKubeClient(kubeURL, kubeToken, *kubeNamespaceName)
+	kubeConfig := &kubernetes.KubeClientConfig{
+		ClusterURL:    kubeURL,
+		BearerToken:   kubeToken,
+		UserNamespace: *kubeNamespaceName,
+	}
+	kc, err := kubernetes.NewKubeClient(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +193,7 @@ func (c *AppsController) getKubeClient(ctx context.Context) (*kubernetes.KubeCli
 
 // getAndCheckKubeClient converts all errors fromgetKubeClient() to Error 401
 // this is for convenience and ensuring consistency
-func (c *AppsController) getAndCheckKubeClient(ctx context.Context) (*kubernetes.KubeClient, error) {
+func (c *AppsController) getAndCheckKubeClient(ctx context.Context) (kubernetes.KubeClientInterface, error) {
 
 	kc, err := c.getKubeClient(ctx)
 	if err != nil {

--- a/kubernetes/apps_kubeclient.go
+++ b/kubernetes/apps_kubeclient.go
@@ -16,19 +16,58 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	kubernetes "k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	rest "k8s.io/client-go/rest"
 
 	"github.com/fabric8-services/fabric8-wit/app"
 )
 
-// KubeClient contains configuration and methods for interacting with Kubernetes cluster
-type KubeClient struct {
-	config        *rest.Config
-	clientset     *kubernetes.Clientset
-	metrics       *metricsClient
-	userNamespace string
-	envMap        map[string]string
+// KubeClientConfig holds configuration data needed to create a new KubeClientInterface
+// with kubernetes.NewKubeClient
+type KubeClientConfig struct {
+	// URL to the Kubernetes cluster's API server
+	ClusterURL string
+	// An authorized token to access the cluster
+	BearerToken string
+	// Kubernetes namespace in the cluster of type 'user'
+	UserNamespace string
+	// Provides access to the Kubernetes REST API, uses default implementation if not set
+	KubeRESTAPIGetter
+	// Provides access to the metrics API, uses default implementation if not set
+	MetricsGetter
+}
+
+// KubeRESTAPIGetter has a method to access the KubeRESTAPI interface
+type KubeRESTAPIGetter interface {
+	GetKubeRESTAPI(config *KubeClientConfig) (KubeRESTAPI, error)
+}
+
+// KubeClientInterface contains configuration and methods for interacting with a Kubernetes cluster
+type KubeClientInterface interface {
+	GetSpace(spaceName string) (*app.SimpleSpace, error)
+	GetApplication(spaceName string, appName string) (*app.SimpleApp, error)
+	GetDeployment(spaceName string, appName string, envName string) (*app.SimpleDeployment, error)
+	ScaleDeployment(spaceName string, appName string, envName string, deployNumber int) (*int, error)
+	GetDeploymentStats(spaceName string, appName string, envName string,
+		startTime time.Time) (*app.SimpleDeploymentStats, error)
+	GetDeploymentStatSeries(spaceName string, appName string, envName string, startTime time.Time,
+		endTime time.Time, limit int) (*app.SimpleDeploymentStatSeries, error)
+	GetEnvironments() ([]*app.SimpleEnvironment, error)
+	GetEnvironment(envName string) (*app.SimpleEnvironment, error)
+	GetPodsInNamespace(nameSpace string, appName string) ([]v1.Pod, error)
+}
+
+type kubeClient struct {
+	config *KubeClientConfig
+	envMap map[string]string
+	KubeRESTAPI
+	MetricsInterface
+}
+
+// KubeRESTAPI collects methods that call out to the Kubernetes API server over the network
+type KubeRESTAPI interface {
+	corev1.CoreV1Interface
 }
 
 type deployment struct {
@@ -37,35 +76,40 @@ type deployment struct {
 	currentUID types.UID
 }
 
-// NewKubeClient creates a KubeClient given a URL to the Kubernetes cluster, an authorized token to
-// access the cluster, and the namespace in that cluster of type 'user'
-func NewKubeClient(clusterURL string, kubeToken string, userNamespace string) (*KubeClient, error) {
-	config := rest.Config{
-		Host:        clusterURL,
-		BearerToken: kubeToken,
+// Receiver for default implementation of KubeRESTAPIGetter and MetricsGetter
+type defaultGetter struct{}
+
+// NewKubeClient creates a KubeClientInterface given a configuration
+func NewKubeClient(config *KubeClientConfig) (KubeClientInterface, error) {
+	// Use default implementation if no KubernetesGetter is specified
+	if config.KubeRESTAPIGetter == nil {
+		config.KubeRESTAPIGetter = defaultGetter{}
 	}
-	clientset, err := kubernetes.NewForConfig(&config)
+	kubeAPI, err := config.GetKubeRESTAPI(config)
 	if err != nil {
 		return nil, err
 	}
 
+	// Use default implementation if no MetricsGetter is specified
+	if config.MetricsGetter == nil {
+		config.MetricsGetter = defaultGetter{}
+	}
 	// In the absence of a better way to get the user's metrics URL,
 	// substitute "api" with "metrics" in user's cluster URL
-	metricsURL, err := getMetricsURLFromAPIURL(clusterURL)
+	metricsURL, err := getMetricsURLFromAPIURL(config.ClusterURL)
 	if err != nil {
 		return nil, err
 	}
 	// Create MetricsClient for talking with Hawkular API
-	metrics, err := newMetricsClient(metricsURL, kubeToken)
+	metrics, err := config.GetMetrics(metricsURL, config.BearerToken)
 	if err != nil {
 		return nil, err
 	}
 
-	kubeClient := new(KubeClient)
-	kubeClient.config = &config
-	kubeClient.clientset = clientset
-	kubeClient.userNamespace = userNamespace
-	kubeClient.metrics = metrics
+	kubeClient := new(kubeClient)
+	kubeClient.config = config
+	kubeClient.KubeRESTAPI = kubeAPI
+	kubeClient.MetricsInterface = metrics
 
 	// Get environments from config map
 	envMap, err := kubeClient.getEnvironmentsFromConfigMap()
@@ -76,8 +120,24 @@ func NewKubeClient(clusterURL string, kubeToken string, userNamespace string) (*
 	return kubeClient, nil
 }
 
+func (defaultGetter) GetKubeRESTAPI(config *KubeClientConfig) (KubeRESTAPI, error) {
+	restConfig := &rest.Config{
+		Host:        config.ClusterURL,
+		BearerToken: config.BearerToken,
+	}
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.CoreV1(), nil
+}
+
+func (defaultGetter) GetMetrics(metricsURL string, bearerToken string) (MetricsInterface, error) {
+	return newMetricsClient(metricsURL, bearerToken)
+}
+
 // GetSpace returns a space matching the provided name, containing all applications that belong to it
-func (kc *KubeClient) GetSpace(spaceName string) (*app.SimpleSpace, error) {
+func (kc *kubeClient) GetSpace(spaceName string) (*app.SimpleSpace, error) {
 	// Get BuildConfigs within the user namespace that have a matching 'space' label
 	// This is similar to how pipelines are displayed in fabric8-ui
 	// https://github.com/fabric8-ui/fabric8-ui/blob/master/src/app/space/create/pipelines/pipelines.component.ts
@@ -105,7 +165,7 @@ func (kc *KubeClient) GetSpace(spaceName string) (*app.SimpleSpace, error) {
 
 // GetApplication retrieves an application with the given space and application names, with the status
 // of that application's deployment in each environment
-func (kc *KubeClient) GetApplication(spaceName string, appName string) (*app.SimpleApp, error) {
+func (kc *kubeClient) GetApplication(spaceName string, appName string) (*app.SimpleApp, error) {
 	// Get all deployments of this app for each environment in this space
 	var deployments []*app.SimpleDeployment
 	for envName := range kc.envMap {
@@ -126,7 +186,7 @@ func (kc *KubeClient) GetApplication(spaceName string, appName string) (*app.Sim
 
 // ScaleDeployment adjusts the desired number of replicas for a specified application, returning the
 // previous number of desired replicas
-func (kc *KubeClient) ScaleDeployment(spaceName string, appName string, envName string, deployNumber int) (*int, error) {
+func (kc *kubeClient) ScaleDeployment(spaceName string, appName string, envName string, deployNumber int) (*int, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
 		return nil, err
@@ -170,7 +230,7 @@ func (kc *KubeClient) ScaleDeployment(spaceName string, appName string, envName 
 
 // GetDeployment returns information about the current deployment of an application within a
 // particular environment. The application must exist within the provided space.
-func (kc *KubeClient) GetDeployment(spaceName string, appName string, envName string) (*app.SimpleDeployment, error) {
+func (kc *kubeClient) GetDeployment(spaceName string, appName string, envName string) (*app.SimpleDeployment, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
 		return nil, err
@@ -205,7 +265,7 @@ func (kc *KubeClient) GetDeployment(spaceName string, appName string, envName st
 
 // GetDeploymentStats returns performance metrics of an application for a period of 1 minute
 // beyond the specified start time, which are then aggregated into a single data point.
-func (kc *KubeClient) GetDeploymentStats(spaceName string, appName string, envName string,
+func (kc *kubeClient) GetDeploymentStats(spaceName string, appName string, envName string,
 	startTime time.Time) (*app.SimpleDeploymentStats, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
@@ -226,11 +286,11 @@ func (kc *KubeClient) GetDeploymentStats(spaceName string, appName string, envNa
 	}
 
 	// Gather the statistics we need about the current deployment
-	cpuUsage, err := kc.metrics.getCPUMetrics(pods, envNS, startTime)
+	cpuUsage, err := kc.GetCPUMetrics(pods, envNS, startTime)
 	if err != nil {
 		return nil, err
 	}
-	memoryUsage, err := kc.metrics.getMemoryMetrics(pods, envNS, startTime)
+	memoryUsage, err := kc.GetMemoryMetrics(pods, envNS, startTime)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +306,7 @@ func (kc *KubeClient) GetDeploymentStats(spaceName string, appName string, envNa
 // GetDeploymentStatSeries returns performance metrics of an application as a time series bounded by
 // the provided time range in startTime and endTime. If there are more data points than the
 // limit argument, only the newest datapoints within that limit are returned.
-func (kc *KubeClient) GetDeploymentStatSeries(spaceName string, appName string, envName string,
+func (kc *kubeClient) GetDeploymentStatSeries(spaceName string, appName string, envName string,
 	startTime time.Time, endTime time.Time, limit int) (*app.SimpleDeploymentStatSeries, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
@@ -268,11 +328,11 @@ func (kc *KubeClient) GetDeploymentStatSeries(spaceName string, appName string, 
 	}
 
 	// Get CPU and memory metrics for pods in deployment
-	cpuMetrics, err := kc.metrics.getCPUMetricsRange(pods, envNS, startTime, endTime, limit)
+	cpuMetrics, err := kc.GetCPUMetricsRange(pods, envNS, startTime, endTime, limit)
 	if err != nil {
 		return nil, err
 	}
-	memoryMetrics, err := kc.metrics.getMemoryMetricsRange(pods, envNS, startTime, endTime, limit)
+	memoryMetrics, err := kc.GetMemoryMetricsRange(pods, envNS, startTime, endTime, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +351,7 @@ func (kc *KubeClient) GetDeploymentStatSeries(spaceName string, appName string, 
 
 // GetEnvironments retrieves information on all environments in the cluster
 // for the current user
-func (kc *KubeClient) GetEnvironments() ([]*app.SimpleEnvironment, error) {
+func (kc *kubeClient) GetEnvironments() ([]*app.SimpleEnvironment, error) {
 	var envs []*app.SimpleEnvironment
 	for envName := range kc.envMap {
 		env, err := kc.GetEnvironment(envName)
@@ -304,7 +364,7 @@ func (kc *KubeClient) GetEnvironments() ([]*app.SimpleEnvironment, error) {
 }
 
 // GetEnvironment returns information on an environment with the provided name
-func (kc *KubeClient) GetEnvironment(envName string) (*app.SimpleEnvironment, error) {
+func (kc *kubeClient) GetEnvironment(envName string) (*app.SimpleEnvironment, error) {
 	envNS, err := kc.getEnvironmentNamespace(envName)
 	if err != nil {
 		return nil, err
@@ -360,13 +420,13 @@ func getTimestampEndpoints(metricsSeries ...[]*app.TimedNumberTuple) (minTime, m
 	return minTime, maxTime
 }
 
-func (kc *KubeClient) getBuildConfigs(space string) ([]string, error) {
+func (kc *kubeClient) getBuildConfigs(space string) ([]string, error) {
 	// BuildConfigs are OpenShift objects, so access REST API using HTTP directly until
 	// there is a Go client for OpenShift
 
 	// BuildConfigs created by fabric8 have a "space" label indicating the space they belong to
 	queryParam := url.QueryEscape("space=" + space)
-	bcURL := fmt.Sprintf("/oapi/v1/namespaces/%s/buildconfigs?labelSelector=%s", kc.userNamespace, queryParam)
+	bcURL := fmt.Sprintf("/oapi/v1/namespaces/%s/buildconfigs?labelSelector=%s", kc.config.UserNamespace, queryParam)
 	result, err := kc.getResource(bcURL, false)
 	if err != nil {
 		return nil, err
@@ -401,11 +461,11 @@ func (kc *KubeClient) getBuildConfigs(space string) ([]string, error) {
 	return buildconfigs, nil
 }
 
-func (kc *KubeClient) getEnvironmentsFromConfigMap() (map[string]string, error) {
+func (kc *kubeClient) getEnvironmentsFromConfigMap() (map[string]string, error) {
 	// fabric8 creates a ConfigMap in the user namespace with information on environments
 	const envConfigMap string = "fabric8-environments"
 	const providerLabel string = "fabric8"
-	configmap, err := kc.clientset.CoreV1().ConfigMaps(kc.userNamespace).Get(envConfigMap, metaV1.GetOptions{})
+	configmap, err := kc.ConfigMaps(kc.config.UserNamespace).Get(envConfigMap, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +498,7 @@ func (kc *KubeClient) getEnvironmentsFromConfigMap() (map[string]string, error) 
 	return envMap, nil
 }
 
-func (kc *KubeClient) getEnvironmentNamespace(envName string) (string, error) {
+func (kc *kubeClient) getEnvironmentNamespace(envName string) (string, error) {
 	envNS, pres := kc.envMap[envName]
 	if !pres {
 		return "", errors.New("Unknown environment: " + envName)
@@ -447,8 +507,8 @@ func (kc *KubeClient) getEnvironmentNamespace(envName string) (string, error) {
 }
 
 // Derived from: https://github.com/fabric8-services/fabric8-tenant/blob/master/openshift/kube_token.go
-func (kc *KubeClient) putResource(url string, putBody []byte) (*string, error) {
-	fullURL := strings.TrimSuffix(kc.config.Host, "/") + url
+func (kc *kubeClient) putResource(url string, putBody []byte) (*string, error) {
+	fullURL := strings.TrimSuffix(kc.config.ClusterURL, "/") + url
 	req, err := http.NewRequest("PUT", fullURL, bytes.NewBuffer(putBody))
 	if err != nil {
 		return nil, err
@@ -477,7 +537,7 @@ func (kc *KubeClient) putResource(url string, putBody []byte) (*string, error) {
 	return &bodyStr, nil
 }
 
-func (kc *KubeClient) getDeploymentConfig(namespace string, appName string, space string) (*deployment, error) {
+func (kc *kubeClient) getDeploymentConfig(namespace string, appName string, space string) (*deployment, error) {
 	dcURL := fmt.Sprintf("/oapi/v1/namespaces/%s/deploymentconfigs/%s", namespace, appName)
 	result, err := kc.getResource(dcURL, true)
 	if err != nil {
@@ -526,7 +586,7 @@ func (kc *KubeClient) getDeploymentConfig(namespace string, appName string, spac
 	return dc, nil
 }
 
-func (kc *KubeClient) getCurrentDeployment(space string, appName string, namespace string) (*deployment, error) {
+func (kc *kubeClient) getCurrentDeployment(space string, appName string, namespace string) (*deployment, error) {
 	// Look up DeploymentConfig corresponding to the application name in the provided environment
 	result, err := kc.getDeploymentConfig(namespace, appName, space)
 	if err != nil {
@@ -572,8 +632,8 @@ func (kc *KubeClient) getCurrentDeployment(space string, appName string, namespa
 	return result, nil
 }
 
-func (kc *KubeClient) getReplicationControllers(namespace string, dcUID types.UID) ([]v1.ReplicationController, error) {
-	rcs, err := kc.clientset.CoreV1().ReplicationControllers(namespace).List(metaV1.ListOptions{})
+func (kc *kubeClient) getReplicationControllers(namespace string, dcUID types.UID) ([]v1.ReplicationController, error) {
+	rcs, err := kc.ReplicationControllers(namespace).List(metaV1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -597,9 +657,9 @@ func (kc *KubeClient) getReplicationControllers(namespace string, dcUID types.UI
 	return rcsForDc, nil
 }
 
-func (kc *KubeClient) getResourceQuota(namespace string) (*app.EnvStats, error) {
+func (kc *kubeClient) getResourceQuota(namespace string) (*app.EnvStats, error) {
 	const computeResources string = "compute-resources"
-	quota, err := kc.clientset.CoreV1().ResourceQuotas(namespace).Get(computeResources, metaV1.GetOptions{})
+	quota, err := kc.ResourceQuotas(namespace).Get(computeResources, metaV1.GetOptions{})
 	if err != nil {
 		return nil, err
 	} else if quota == nil {
@@ -665,19 +725,19 @@ func quantityToFloat64(q resource.Quantity) (float64, error) {
 }
 
 // GetPodsInNamespace - return all pods in namepsace 'nameSpace' and application 'appName'
-func (kc *KubeClient) GetPodsInNamespace(nameSpace string, appName string) ([]v1.Pod, error) {
+func (kc *kubeClient) GetPodsInNamespace(nameSpace string, appName string) ([]v1.Pod, error) {
 	listOptions := metaV1.ListOptions{
 		LabelSelector: "app=" + appName,
 	}
-	pods, err := kc.clientset.CoreV1().Pods(nameSpace).List(listOptions)
+	pods, err := kc.Pods(nameSpace).List(listOptions)
 	if err != nil {
 		return nil, err
 	}
 	return pods.Items, nil
 }
 
-func (kc *KubeClient) getPods(namespace string, uid types.UID) ([]v1.Pod, error) {
-	pods, err := kc.clientset.CoreV1().Pods(namespace).List(metaV1.ListOptions{})
+func (kc *kubeClient) getPods(namespace string, uid types.UID) ([]v1.Pod, error) {
+	pods, err := kc.Pods(namespace).List(metaV1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -701,7 +761,7 @@ func (kc *KubeClient) getPods(namespace string, uid types.UID) ([]v1.Pod, error)
 	return appPods, nil
 }
 
-func (kc *KubeClient) getPodStatus(pods []v1.Pod) (*app.PodStats, error) {
+func (kc *kubeClient) getPodStatus(pods []v1.Pod) (*app.PodStats, error) {
 	var starting, running, stopping int
 	/*
 	 * TODO Logic for pod phases in web console is calculated in the UI:
@@ -737,9 +797,9 @@ func (kc *KubeClient) getPodStatus(pods []v1.Pod) (*app.PodStats, error) {
 }
 
 // Derived from: https://github.com/fabric8-services/fabric8-tenant/blob/master/openshift/kube_token.go
-func (kc *KubeClient) getResource(url string, allowMissing bool) (map[interface{}]interface{}, error) {
+func (kc *kubeClient) getResource(url string, allowMissing bool) (map[interface{}]interface{}, error) {
 	var body []byte
-	fullURL := strings.TrimSuffix(kc.config.Host, "/") + url
+	fullURL := strings.TrimSuffix(kc.config.ClusterURL, "/") + url
 	req, err := http.NewRequest("GET", fullURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/kubernetes/apps_kubeclient_blackbox_test.go
+++ b/kubernetes/apps_kubeclient_blackbox_test.go
@@ -1,0 +1,384 @@
+package kubernetes_test
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fabric8-services/fabric8-wit/app"
+	"github.com/fabric8-services/fabric8-wit/kubernetes"
+	resource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+// Used for equality comparisons between float64s
+const fltEpsilon = 0.00000001
+
+type testKube struct {
+	kubernetes.KubeRESTAPI // Allows us to only implement methods we'll use
+	getter                 *testKubeGetter
+	configMapHolder        *testConfigMap
+	quotaHolder            *testResourceQuota
+}
+
+type testKubeGetter struct {
+	cmInput *configMapInput
+	rqInput *resourceQuotaInput
+	result  *testKube
+}
+
+// Config Maps fakes
+
+type configMapInput struct {
+	data       map[string]string
+	labels     map[string]string
+	shouldFail bool
+}
+
+var defaultConfigMapInput *configMapInput = &configMapInput{
+	labels: map[string]string{"provider": "fabric8"},
+	data: map[string]string{
+		"run":   "name: Run\nnamespace: my-run\norder: 1",
+		"stage": "name: Stage\nnamespace: my-stage\norder: 0",
+	},
+}
+
+type testConfigMap struct {
+	corev1.ConfigMapInterface
+	input     *configMapInput
+	namespace string
+	configMap *v1.ConfigMap
+}
+
+func (tk *testKube) ConfigMaps(ns string) corev1.ConfigMapInterface {
+	input := tk.getter.cmInput
+	if input == nil {
+		input = defaultConfigMapInput
+	}
+	result := &testConfigMap{
+		input:     input,
+		namespace: ns,
+	}
+	tk.configMapHolder = result
+	return result
+}
+
+func (cm *testConfigMap) Get(name string, options metav1.GetOptions) (*v1.ConfigMap, error) {
+	result := &v1.ConfigMap{
+		Data: cm.input.data,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: cm.input.labels,
+		},
+	}
+	cm.configMap = result
+	return result, nil
+}
+
+// Resource Quota fakes
+
+type resourceQuotaInput struct {
+	name       string
+	namespace  string
+	hard       map[v1.ResourceName]float64
+	used       map[v1.ResourceName]float64
+	shouldFail bool
+}
+
+var defaultResourceQuotaInput *resourceQuotaInput = &resourceQuotaInput{
+	name:      "run",
+	namespace: "my-run",
+	hard: map[v1.ResourceName]float64{
+		v1.ResourceLimitsCPU:    0.7,
+		v1.ResourceLimitsMemory: 1024,
+	},
+	used: map[v1.ResourceName]float64{
+		v1.ResourceLimitsCPU:    0.4,
+		v1.ResourceLimitsMemory: 512,
+	},
+}
+
+type testResourceQuota struct {
+	corev1.ResourceQuotaInterface
+	input     *resourceQuotaInput
+	namespace string
+	quota     *v1.ResourceQuota
+}
+
+func (tk *testKube) ResourceQuotas(ns string) corev1.ResourceQuotaInterface {
+	input := tk.getter.rqInput
+	if input == nil {
+		input = defaultResourceQuotaInput
+	}
+	result := &testResourceQuota{
+		input:     input,
+		namespace: ns,
+	}
+	tk.quotaHolder = result
+	return result
+}
+
+func (rq *testResourceQuota) Get(name string, options metav1.GetOptions) (*v1.ResourceQuota, error) {
+	if rq.input.hard == nil || rq.input.used == nil { // Used to indicate no quota object
+		return nil, nil
+	}
+	hardQuantity, err := stringToQuantityMap(rq.input.hard)
+	if err != nil {
+		return nil, err
+	}
+	usedQuantity, err := stringToQuantityMap(rq.input.used)
+	if err != nil {
+		return nil, err
+	}
+	result := &v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.ResourceQuotaStatus{
+			Hard: hardQuantity,
+			Used: usedQuantity,
+		},
+	}
+	rq.quota = result
+	return result, nil
+}
+
+func stringToQuantityMap(input map[v1.ResourceName]float64) (v1.ResourceList, error) {
+	result := make(map[v1.ResourceName]resource.Quantity)
+	for k, v := range input {
+		strVal := strconv.FormatFloat(v, 'f', -1, 64)
+		q, err := resource.ParseQuantity(strVal)
+		if err != nil {
+			return nil, err
+		}
+		result[k] = q
+	}
+	return result, nil
+}
+
+func (getter *testKubeGetter) GetKubeRESTAPI(config *kubernetes.KubeClientConfig) (kubernetes.KubeRESTAPI, error) {
+	mock := new(testKube)
+	// Doubly-linked for access by tests
+	mock.getter = getter
+	getter.result = mock
+	return mock, nil
+}
+
+type testMetricsGetter struct {
+	metricsURL  string
+	bearerToken string
+}
+
+type testMetrics struct{}
+
+func (getter *testMetricsGetter) GetMetrics(metricsURL string, bearerToken string) (kubernetes.MetricsInterface, error) {
+	getter.metricsURL = metricsURL
+	getter.bearerToken = bearerToken
+	return testMetrics{}, nil
+}
+
+func (testMetrics) GetCPUMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error) {
+	return nil, nil // TODO
+}
+
+func (testMetrics) GetCPUMetricsRange(pods []v1.Pod, namespace string, startTime time.Time, endTime time.Time,
+	limit int) ([]*app.TimedNumberTuple, error) {
+	return nil, nil // TODO
+}
+
+func (testMetrics) GetMemoryMetrics(pods []v1.Pod, namespace string, startTime time.Time) (*app.TimedNumberTuple, error) {
+	return nil, nil // TODO
+}
+
+func (testMetrics) GetMemoryMetricsRange(pods []v1.Pod, namespace string, startTime time.Time, endTime time.Time,
+	limit int) ([]*app.TimedNumberTuple, error) {
+	return nil, nil // TODO
+}
+
+func TestGetMetrics(t *testing.T) {
+	kubeGetter := &testKubeGetter{
+		cmInput: defaultConfigMapInput,
+	}
+	metricsGetter := &testMetricsGetter{}
+
+	token := "myToken"
+	testCases := []struct {
+		clusterURL    string
+		expectedURL   string
+		shouldSucceed bool
+	}{
+		{"https://api.myCluster.url:443/cluster", "https://metrics.myCluster.url", true},
+		{"https://myCluster.url:443/cluster", "", false},
+	}
+
+	for _, testCase := range testCases {
+		config := &kubernetes.KubeClientConfig{
+			ClusterURL:        testCase.clusterURL,
+			BearerToken:       token,
+			UserNamespace:     "myNamespace",
+			KubeRESTAPIGetter: kubeGetter,
+			MetricsGetter:     metricsGetter,
+		}
+		_, err := kubernetes.NewKubeClient(config)
+		if testCase.shouldSucceed {
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, testCase.expectedURL, metricsGetter.metricsURL, "Incorrect Metrics URL")
+			assert.Equal(t, token, metricsGetter.bearerToken, "Incorrect bearer token")
+		} else {
+			if err == nil {
+				t.Error("Expected error, but was successful")
+			}
+		}
+	}
+}
+
+func TestConfigMapEnvironments(t *testing.T) {
+	testCases := []*configMapInput{
+		{
+			labels: map[string]string{"provider": "fabric8"},
+			data: map[string]string{
+				"run":   "name: Run\nnamespace: my-run\norder: 1",
+				"stage": "name: Stage\nnamespace: my-stage\norder: 0",
+			},
+		},
+		{
+			labels: map[string]string{"provider": "fabric8"},
+			data:   map[string]string{},
+		},
+		{
+			labels: map[string]string{"provider": "fabric8"},
+			data: map[string]string{
+				"run": "name: Run\nnamespace my-run\norder: 1", // Missing colon
+			},
+			shouldFail: true,
+		},
+		{
+			labels: map[string]string{"provider": "fabric8"},
+			data: map[string]string{
+				"run": "name: Run\nns: my-run\norder: 1", // Missing namespace
+			},
+			shouldFail: true,
+		},
+		{
+			shouldFail: true, // No provider
+		},
+	}
+	kubeGetter := &testKubeGetter{}
+	metricsGetter := &testMetricsGetter{}
+	userNamespace := "myNamespace"
+	config := &kubernetes.KubeClientConfig{
+		ClusterURL:        "http://api.myCluster",
+		BearerToken:       "myToken",
+		UserNamespace:     userNamespace,
+		KubeRESTAPIGetter: kubeGetter,
+		MetricsGetter:     metricsGetter,
+	}
+
+	expectedName := "fabric8-environments"
+	for _, testCase := range testCases {
+		kubeGetter.cmInput = testCase
+		_, err := kubernetes.NewKubeClient(config)
+		if testCase.shouldFail {
+			assert.Error(t, err)
+		} else {
+			if !assert.NoError(t, err) {
+				continue
+			}
+			configMapHolder := kubeGetter.result.configMapHolder
+			if !assert.NotNil(t, configMapHolder, "No ConfigMap created by test") {
+				continue
+			}
+			assert.Equal(t, userNamespace, configMapHolder.namespace, "ConfigMap obtained from wrong namespace")
+			configMap := configMapHolder.configMap
+			if !assert.NotNil(t, configMap, "Never sent ConfigMap GET") {
+				continue
+			}
+			assert.Equal(t, expectedName, configMap.Name, "Incorrect ConfigMap name")
+		}
+	}
+}
+
+func TestGetEnvironment(t *testing.T) {
+	testCases := []*resourceQuotaInput{
+		{
+			name:      "run",
+			namespace: "my-run",
+			hard: map[v1.ResourceName]float64{
+				v1.ResourceLimitsCPU:    0.7,
+				v1.ResourceLimitsMemory: 1024,
+			},
+			used: map[v1.ResourceName]float64{
+				v1.ResourceLimitsCPU:    0.4,
+				v1.ResourceLimitsMemory: 512,
+			},
+		},
+		{
+			name:      "doesNotExist", // Bad environment name
+			namespace: "my-run",
+			hard: map[v1.ResourceName]float64{
+				v1.ResourceLimitsCPU:    0.7,
+				v1.ResourceLimitsMemory: 1024,
+			},
+			used: map[v1.ResourceName]float64{
+				v1.ResourceLimitsCPU:    0.4,
+				v1.ResourceLimitsMemory: 512,
+			},
+			shouldFail: true,
+		},
+		{
+			name:       "run",
+			namespace:  "my-run",
+			shouldFail: true, // No quantities, so our test impl returns nil
+		},
+	}
+	kubeGetter := &testKubeGetter{}
+	metricsGetter := &testMetricsGetter{}
+	config := &kubernetes.KubeClientConfig{
+		ClusterURL:        "http://api.myCluster",
+		BearerToken:       "myToken",
+		UserNamespace:     "myNamespace",
+		KubeRESTAPIGetter: kubeGetter,
+		MetricsGetter:     metricsGetter,
+	}
+
+	kc, err := kubernetes.NewKubeClient(config)
+	assert.NoError(t, err)
+	for _, testCase := range testCases {
+		kubeGetter.rqInput = testCase
+		env, err := kc.GetEnvironment(testCase.name)
+		if testCase.shouldFail {
+			assert.Error(t, err)
+		} else {
+			if !assert.NoError(t, err) {
+				continue
+			}
+
+			quotaHolder := kubeGetter.result.quotaHolder
+			if !assert.NotNil(t, quotaHolder, "No ResourceQuota created by test") {
+				continue
+			}
+			assert.Equal(t, testCase.namespace, quotaHolder.namespace, "Quota retrieved from wrong namespace")
+			quota := quotaHolder.quota
+			if !assert.NotNil(t, quota, "Never sent ResourceQuota GET") {
+				continue
+			}
+			assert.Equal(t, "compute-resources", quota.Name, "Wrong ResourceQuota name")
+			assert.Equal(t, testCase.name, *env.Name, "Wrong environment name")
+
+			cpuQuota := env.Quota.Cpucores
+			assert.InEpsilon(t, testCase.hard[v1.ResourceLimitsCPU], *cpuQuota.Quota, fltEpsilon, "Incorrect CPU quota")
+			assert.InEpsilon(t, testCase.used[v1.ResourceLimitsCPU], *cpuQuota.Used, fltEpsilon, "Incorrect CPU usage")
+
+			memQuota := env.Quota.Memory
+			assert.InEpsilon(t, testCase.hard[v1.ResourceLimitsMemory], *memQuota.Quota, fltEpsilon, "Incorrect memory quota")
+			assert.InEpsilon(t, testCase.used[v1.ResourceLimitsMemory], *memQuota.Used, fltEpsilon, "Incorrect memory usage")
+		}
+	}
+}


### PR DESCRIPTION
This PR refactors the exported methods in apps_kubeclient.go to implement an interface, KubeClientInterface. This should hopefully make testing the controller code easier. I also had to do a bunch of refactoring in apps_kubeclient.go and apps_metrics.go to be able to test them without calling out to real Kubernetes/Hawkular.

I've added some initial unit tests that test NewKubeClient and GetEnvironment, with more tests to follow.